### PR TITLE
OreDict features

### DIFF
--- a/MineTweaker3-API/src/main/java/minetweaker/api/oredict/IOreDictEntry.java
+++ b/MineTweaker3-API/src/main/java/minetweaker/api/oredict/IOreDictEntry.java
@@ -26,7 +26,7 @@ public interface IOreDictEntry extends IIngredient {
 	@ZenGetter("empty")
 	public boolean isEmpty();
 
-    @ZenGetter("firstItem")
+	@ZenGetter("firstItem")
 	public IItemStack getFirstItem();
 
 	@ZenMethod

--- a/MineTweaker3-API/src/main/java/minetweaker/api/oredict/IOreDictEntry.java
+++ b/MineTweaker3-API/src/main/java/minetweaker/api/oredict/IOreDictEntry.java
@@ -26,6 +26,9 @@ public interface IOreDictEntry extends IIngredient {
 	@ZenGetter("empty")
 	public boolean isEmpty();
 
+    @ZenGetter("firstItem")
+	public IItemStack getFirstItem();
+
 	@ZenMethod
 	public void add(IItemStack item);
 

--- a/MineTweaker3-MC1710-Main/src/main/java/minetweaker/mc1710/brackets/OreBracketHandler.java
+++ b/MineTweaker3-MC1710-Main/src/main/java/minetweaker/mc1710/brackets/OreBracketHandler.java
@@ -6,8 +6,11 @@
 
 package minetweaker.mc1710.brackets;
 
+import java.util.ArrayList;
 import java.util.List;
+import java.util.regex.Pattern;
 import minetweaker.IBracketHandler;
+import minetweaker.MineTweakerAPI;
 import minetweaker.annotations.BracketHandler;
 import minetweaker.mc1710.oredict.MCOreDictEntry;
 import minetweaker.api.oredict.IOreDictEntry;
@@ -31,6 +34,20 @@ public class OreBracketHandler implements IBracketHandler {
 	public static IOreDictEntry getOre(String name) {
 		return new MCOreDictEntry(name);
 	}
+    
+    public static List<IOreDictEntry> getOreList(String wildcardName) {
+        List<IOreDictEntry> result = new ArrayList<IOreDictEntry>();
+        Pattern wildcardPattern = Pattern.compile(wildcardName.replaceAll("\\*", ".+"));
+        
+        for (IOreDictEntry someOreDict : MineTweakerAPI.oreDict.getEntries()) {
+            String oreDictName = someOreDict.getName();
+            if (wildcardPattern.matcher(oreDictName).matches()) {
+                result.add(getOre(oreDictName));
+            }
+        }
+        
+        return result;
+    }
 
 	@Override
 	public IZenSymbol resolve(IEnvironmentGlobal environment, List<Token> tokens) {
@@ -67,7 +84,7 @@ public class OreBracketHandler implements IBracketHandler {
 			IJavaMethod method = JavaMethod.get(
 					GlobalRegistry.getTypeRegistry(),
 					OreBracketHandler.class,
-					"getOre",
+					name.contains("*") ? "getOreList" : "getOre",
 					String.class);
 
 			return new ExpressionCallStatic(

--- a/MineTweaker3-MC1710-Main/src/main/java/minetweaker/mc1710/oredict/MCOreDictEntry.java
+++ b/MineTweaker3-MC1710-Main/src/main/java/minetweaker/mc1710/oredict/MCOreDictEntry.java
@@ -68,6 +68,15 @@ public class MCOreDictEntry implements IOreDictEntry {
 		}
 	}
 
+    @Override
+    public IItemStack getFirstItem() {
+        List<ItemStack> items = OreDictionary.getOres(id);
+        if (items.isEmpty()) {
+            return null;
+        }
+        return getIItemStackWildcardSize(items.get(0));
+    }
+
 	@Override
 	public void addAll(IOreDictEntry entry) {
 		if (entry instanceof MCOreDictEntry) {

--- a/MineTweaker3-MC18-Main/src/main/java/minetweaker/mc18/brackets/OreBracketHandler.java
+++ b/MineTweaker3-MC18-Main/src/main/java/minetweaker/mc18/brackets/OreBracketHandler.java
@@ -84,7 +84,7 @@ public class OreBracketHandler implements IBracketHandler {
 			IJavaMethod method = JavaMethod.get(
 					GlobalRegistry.getTypeRegistry(),
 					OreBracketHandler.class,
-					"getOre",
+					name.contains("*") ? "getOreList" : "getOre",
 					String.class);
 
 			return new ExpressionCallStatic(

--- a/MineTweaker3-MC18-Main/src/main/java/minetweaker/mc18/brackets/OreBracketHandler.java
+++ b/MineTweaker3-MC18-Main/src/main/java/minetweaker/mc18/brackets/OreBracketHandler.java
@@ -6,9 +6,11 @@
 
 package minetweaker.mc18.brackets;
 
+import java.util.ArrayList;
 import java.util.List;
-
+import java.util.regex.Pattern;
 import minetweaker.IBracketHandler;
+import minetweaker.MineTweakerAPI;
 import minetweaker.annotations.BracketHandler;
 import minetweaker.api.oredict.IOreDictEntry;
 import minetweaker.mc18.oredict.MCOreDictEntry;
@@ -32,6 +34,20 @@ public class OreBracketHandler implements IBracketHandler {
 	public static IOreDictEntry getOre(String name) {
 		return new MCOreDictEntry(name);
 	}
+    
+    public static List<IOreDictEntry> getOreList(String wildcardName) {
+        List<IOreDictEntry> result = new ArrayList<IOreDictEntry>();
+        Pattern wildcardPattern = Pattern.compile(wildcardName.replaceAll("\\*", ".+"));
+        
+        for (IOreDictEntry someOreDict : MineTweakerAPI.oreDict.getEntries()) {
+            String oreDictName = someOreDict.getName();
+            if (wildcardPattern.matcher(oreDictName).matches()) {
+                result.add(getOre(oreDictName));
+            }
+        }
+        
+        return result;
+    }
 
 	@Override
 	public IZenSymbol resolve(IEnvironmentGlobal environment, List<Token> tokens) {

--- a/MineTweaker3-MC18-Main/src/main/java/minetweaker/mc18/oredict/MCOreDictEntry.java
+++ b/MineTweaker3-MC18-Main/src/main/java/minetweaker/mc18/oredict/MCOreDictEntry.java
@@ -60,6 +60,15 @@ public class MCOreDictEntry implements IOreDictEntry {
 		return OreDictionary.getOres(getName()).isEmpty();
 	}
 
+    @Override
+    public IItemStack getFirstItem() {
+        List<ItemStack> items = OreDictionary.getOres(getName());
+        if (items.isEmpty()) {
+            return null;
+        }
+        return getIItemStackWildcardSize(items.get(0));
+    }
+
 	@Override
 	public void add(IItemStack item) {
 		ItemStack stack = getItemStack(item);


### PR DESCRIPTION
Prepare rotten tomatoes.

For what the firstItem field? Some ore dictionaries have an only one item and this item has a bad identifier. Look at GregTech things. I think it's easier to write ore dict name instead awful identifier.

For what the ore dict wildcard? Many cases... but I'm using it in the one, for the time being.
Next 'wildcarded' ore dicts are correct
```
<ore:ingot*>
<ore:*Gold>
<ore:gem*?Topaz>
<ore:*Hull*>
```
Any place and many times.