### PR TITLE
Lowercase the modid

### DIFF
--- a/MineTweaker3-MC11-Main/src/main/java/com/blamejared/ctgui/MTRecipe.java
+++ b/MineTweaker3-MC11-Main/src/main/java/com/blamejared/ctgui/MTRecipe.java
@@ -14,7 +14,7 @@ import java.util.List;
 
 import static com.blamejared.ctgui.reference.Reference.*;
 
-@Mod(modid = MOD_ID, name = MOD_NAME, version = VERSION, clientSideOnly = true, dependencies = "required-after:MineTweaker3;")
+@Mod(modid = MOD_ID, name = MOD_NAME, version = VERSION, clientSideOnly = true, dependencies = "required-after:minetweaker3;")
 public class MTRecipe {
 
     @Mod.Instance(MOD_ID)

--- a/MineTweaker3-MC11-Main/src/main/java/minetweaker/mc11/MineTweakerMod.java
+++ b/MineTweaker3-MC11-Main/src/main/java/minetweaker/mc11/MineTweakerMod.java
@@ -43,7 +43,7 @@ import java.io.File;
 @Mod(modid = MineTweakerMod.MODID, name = MineTweakerMod.NAME, version = "3.0.14", dependencies = "after:JEI;")
 public class MineTweakerMod {
 	
-	public static final String MODID = "MineTweaker3";
+	public static final String MODID = "minetweaker3";
 	public static final String NAME = "MineTweaker 3";
 	public static final String MCVERSION = "1.10.2";
 	

--- a/MineTweaker3-MC11-Main/src/main/resources/mcmod.info
+++ b/MineTweaker3-MC11-Main/src/main/resources/mcmod.info
@@ -1,6 +1,6 @@
 [
 {
-  "modid": "MineTweaker3",
+  "modid": "minetweaker3",
   "name": "MineTweaker 3",
   "version": "${version}",
   "mcversion": "${mcversion}",


### PR DESCRIPTION
lowercase mod names are enforced in 1.11.

If the modid has any uppercase letters in it, the mod is rejected from loading and the game refuses to continue because CT-GUI depends on it.

This PR lowercases the MineTweaker modid so that loading can continue.