### PR TITLE
Fixed hiding some items with NBT with a wildcard

### DIFF
--- a/MineTweaker3-MC1112-Main/src/main/java/minetweaker/mc1112/MineTweakerMod.java
+++ b/MineTweaker3-MC1112-Main/src/main/java/minetweaker/mc1112/MineTweakerMod.java
@@ -37,7 +37,7 @@ import java.util.*;
  *
  * @author Stan Hebben
  */
-@Mod(modid = MineTweakerMod.MODID, version = "3.0.26", name = MineTweakerMod.NAME, dependencies = "after:jei@[4.2.6.238,)")
+@Mod(modid = MineTweakerMod.MODID, version = "3.0.26", name = MineTweakerMod.NAME, dependencies = "after:jei@[4.5.0.287,)")
 public class MineTweakerMod {
     
     public static final String MODID = "crafttweaker";

--- a/MineTweaker3-MC1112-Mod-JEI/build.gradle
+++ b/MineTweaker3-MC1112-Mod-JEI/build.gradle
@@ -33,7 +33,7 @@ dependencies {
     compile project(':ZenScript')
     compile project(':MineTweaker3-API')
     compile project(':MineTweaker3-MC1112-Main')
-    deobfCompile "mezz.jei:jei_1.11.2:4.4.1.285"
+    deobfCompile "mezz.jei:jei_1.11.2:4.5.0.289"
 }
 
 task makeRegistry(type: RegisterZenClassesTask) {

--- a/MineTweaker3-MC1112-Mod-JEI/src/main/java/minetweaker/mods/jei/JEI.java
+++ b/MineTweaker3-MC1112-Mod-JEI/src/main/java/minetweaker/mods/jei/JEI.java
@@ -63,7 +63,7 @@ public class JEI {
         
         @Override
         public void apply() {
-                JEIAddonPlugin.itemRegistry.removeIngredientsAtRuntime(ItemStack.class, Collections.singletonList(stack));
+            JEIAddonPlugin.itemRegistry.removeIngredientsAtRuntime(ItemStack.class, JEIAddonPlugin.getSubTypes(stack));
         }
         
         @Override
@@ -73,7 +73,7 @@ public class JEI {
         
         @Override
         public void undo() {
-                JEIAddonPlugin.itemRegistry.addIngredientsAtRuntime(ItemStack.class, Collections.singletonList(stack));
+            JEIAddonPlugin.itemRegistry.addIngredientsAtRuntime(ItemStack.class, JEIAddonPlugin.getSubTypes(stack));
         }
         
         @Override

--- a/MineTweaker3-MC1112-Mod-JEI/src/main/java/minetweaker/mods/jei/JEIAddonPlugin.java
+++ b/MineTweaker3-MC1112-Mod-JEI/src/main/java/minetweaker/mods/jei/JEIAddonPlugin.java
@@ -2,8 +2,13 @@ package minetweaker.mods.jei;
 
 import mezz.jei.api.*;
 import mezz.jei.api.ingredients.*;
+import mezz.jei.api.recipe.IRecipeCategoryRegistration;
 import minetweaker.MineTweakerAPI;
 import minetweaker.api.compat.DummyJEIRecipeRegistry;
+import net.minecraft.item.ItemStack;
+
+import java.util.Collections;
+import java.util.List;
 
 
 @mezz.jei.api.JEIPlugin
@@ -12,7 +17,7 @@ public class JEIAddonPlugin implements IModPlugin {
     public static IJeiHelpers jeiHelpers;
     public static IIngredientRegistry itemRegistry;
     public static IRecipeRegistry recipeRegistry;
-    public static IItemListOverlay itemListOverlay;
+    public static IIngredientHelper<ItemStack> ingredientHelper;
 
     @Override
     public void registerItemSubtypes(ISubtypeRegistry subtypeRegistry) {
@@ -25,20 +30,27 @@ public class JEIAddonPlugin implements IModPlugin {
     }
 
     @Override
+    public void registerCategories(IRecipeCategoryRegistration registry) {
+
+    }
+
+    @Override
     public void register(IModRegistry registry) {
         jeiHelpers = registry.getJeiHelpers();
         itemRegistry = registry.getIngredientRegistry();
+        ingredientHelper = itemRegistry.getIngredientHelper(ItemStack.class);
     }
 
     @Override
     public void onRuntimeAvailable(IJeiRuntime iJeiRuntime) {
         recipeRegistry = iJeiRuntime.getRecipeRegistry();
-        itemListOverlay = iJeiRuntime.getItemListOverlay();
-        
+
         if(MineTweakerAPI.getIjeiRecipeRegistry() instanceof DummyJEIRecipeRegistry) {
             MineTweakerAPI.setIjeiRecipeRegistry(new JEIRecipeRegistry(recipeRegistry, jeiHelpers));
         }
     }
 
-
+    public static List<ItemStack> getSubTypes(ItemStack stack) {
+        return JEIAddonPlugin.ingredientHelper.expandSubtypes(Collections.singletonList(stack));
+    }
 }


### PR DESCRIPTION
In JEI you can add a Subtype Interpreter add data to a identifier string when comparing items. 
With the added things from mods in the identifier a wildcard identifier don't match, so the fix is to get all subitems if the item has a wildcard and hide all of them that way.
Alos updated the JEI API and the required version needed for jei.