### PR TITLE
[1.12] Fixed addAll with ore dict not working

### DIFF
--- a/CraftTweaker2-MC1120-Main/src/main/java/crafttweaker/mc1120/oredict/MCOreDictEntry.java
+++ b/CraftTweaker2-MC1120-Main/src/main/java/crafttweaker/mc1120/oredict/MCOreDictEntry.java
@@ -74,7 +74,7 @@ public class MCOreDictEntry implements IOreDictEntry {
     @Override
     public void addAll(IOreDictEntry entry) {
         if(entry instanceof MCOreDictEntry) {
-            CraftTweakerAPI.apply(new ActionOreDictMirror(id, ((MCOreDictEntry) entry).id));
+            CraftTweakerAPI.apply(new ActionOreDictAddAll(id, ((MCOreDictEntry) entry).id));
         } else {
             CraftTweakerAPI.logError("not a valid entry");
         }


### PR DESCRIPTION
The addition and removal of ore dict entries works as it is, was just the addAll that was set to mirror and therefore not working. 
This works as it is because the ore dict entries are added/removed before the baking of the Ore Dict map.
Tested crafting, viewing in crafting book, viewing in JEI and getting the ore dict names in the tooltip with Actually Additions.