### PR TITLE
Mod entities bug fix

### DIFF
--- a/MineTweaker3-MC1112-Main/src/main/java/minetweaker/mc1112/game/MCGame.java
+++ b/MineTweaker3-MC1112-Main/src/main/java/minetweaker/mc1112/game/MCGame.java
@@ -1,5 +1,6 @@
 package minetweaker.mc1112.game;
 
+import com.google.common.collect.Iterables;
 import minetweaker.*;
 import minetweaker.api.block.IBlockDefinition;
 import minetweaker.api.entity.IEntityDefinition;
@@ -66,7 +67,8 @@ public class MCGame implements IGame {
     
     @Override
     public List<IEntityDefinition> getEntities() {
-        if(ENTITY_DEFINITIONS.isEmpty()) {
+        if(Iterables.size(ForgeRegistries.ENTITIES) != ENTITY_DEFINITIONS.size()) {
+            ENTITY_DEFINITIONS.clear();
             ForgeRegistries.ENTITIES.forEach((entry) -> {
                 ENTITY_DEFINITIONS.add(new MCEntityDefinition(entry.getEntityClass(), entry.getName()));
             });


### PR DESCRIPTION
Fixed an entity list bug with latest versions of MTLib (and other addons that will try to reload CraftTweaker in preInit event).
In other words, entities from mods should be now visible to CraftTweaker when player uses MTLib.

I checked. `/mt entities` produces a full list of entities regardless of MTLib presence.
And entities for mods are accessible now by typing something like `<entity:blueslime>` in the .zs script.